### PR TITLE
게시판 CRUD API 구현

### DIFF
--- a/src/main/kotlin/io/devchw/coderabbit/BoardController.kt
+++ b/src/main/kotlin/io/devchw/coderabbit/BoardController.kt
@@ -1,0 +1,72 @@
+package io.devchw.coderabbit
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * @author DevCHW
+ * @since 2025-06-05
+ */
+@RestController
+@RequestMapping("/api/board")
+class BoardController {
+
+    private val posts = mutableMapOf<Long, Post>()
+    private val idGenerator = AtomicLong(1)
+
+    // 게시물 생성
+    @PostMapping
+    fun createPost(@RequestBody post: Post): ResponseEntity<Post> {
+        val id = idGenerator.getAndIncrement()
+        post.id = id
+        posts[id] = post
+        return ResponseEntity.status(HttpStatus.CREATED).body(post)
+    }
+
+    // 게시물 목록 조회
+    @GetMapping
+    fun getPosts(): ResponseEntity<List<Post>> {
+        return ResponseEntity.ok(posts.values.toList())
+    }
+
+    // 게시물 상세 조회
+    @GetMapping("/{id}")
+    fun getPost(@PathVariable id: Long): ResponseEntity<Post> {
+        val post = posts[id]
+        return if (post != null) {
+            ResponseEntity.ok(post)
+        } else {
+            ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+        }
+    }
+
+    // 게시물 수정
+    @PutMapping("/{id}")
+    fun updatePost(@PathVariable id: Long, @RequestBody updatedPost: Post): ResponseEntity<Post> {
+        if (!posts.containsKey(id)) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+        }
+        updatedPost.id = id
+        posts[id] = updatedPost
+        return ResponseEntity.ok(updatedPost)
+    }
+
+    // 게시물 삭제
+    @DeleteMapping("/{id}")
+    fun deletePost(@PathVariable id: Long): ResponseEntity<Void> {
+        if (!posts.containsKey(id)) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+        }
+        posts.remove(id)
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+    }
+}

--- a/src/main/kotlin/io/devchw/coderabbit/Post.kt
+++ b/src/main/kotlin/io/devchw/coderabbit/Post.kt
@@ -1,0 +1,11 @@
+package io.devchw.coderabbit
+
+/**
+ * @author DevCHW
+ * @since 2025-06-05
+ */
+data class Post(
+    var id: Long? = null,
+    var title: String,
+    var content: String
+)


### PR DESCRIPTION
### 작업 내용
- 게시판 CRUD API 구현.
- `Map`을 사용해 간단한 데이터 저장소로 활용.

### 주요 기능
1. **게시물 생성** (`POST /api/board`)
2. **게시물 목록 조회** (`GET /api/board`)
3. **게시물 상세 조회** (`GET /api/board/{id}`)
4. **게시물 수정** (`PUT /api/board/{id}`)
5. **게시물 삭제** (`DELETE /api/board/{id}`)

### 구현 방식
- 데이터 클래스 작성 (필드: , , ). `Post``id``title``content`
- 으로 ID 자동 생성 및 관리. `AtomicLong`
- HTTP 상태 코드 201, 200, 404, 204 적절히 반환.

### 비고
- 현재 데이터는 `Map`에 저장되며 서버 종료 시 초기화됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a board post system with RESTful API endpoints for creating, viewing, updating, and deleting posts.
  - Added a new post model supporting title and content fields.

- **Bug Fixes**
  - Ensured appropriate HTTP status codes are returned for all API operations, including handling of not-found cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->