### PR TITLE
게시판 CRUD API 구현

### DIFF
--- a/src/main/kotlin/io/devchw/coderabbit/BoardController.kt
+++ b/src/main/kotlin/io/devchw/coderabbit/BoardController.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.concurrent.atomic.AtomicLong
+import org.springframework.beans.factory.annotation.Autowired
 
 /**
  * @author DevCHW
@@ -18,7 +19,9 @@ import java.util.concurrent.atomic.AtomicLong
  */
 @RestController
 @RequestMapping("/api/board")
-class BoardController {
+class BoardController(
+    @Autowired private val commentController: CommentController
+) {
 
     private val posts = mutableMapOf<Long, Post>()
     private val idGenerator = AtomicLong(1)
@@ -98,6 +101,10 @@ class BoardController {
         if (!posts.containsKey(id)) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
         }
+
+        // 게시물과 관련된 모든 댓글 삭제
+        commentController.deleteAllCommentsForPost(id)
+
         posts.remove(id)
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }

--- a/src/main/kotlin/io/devchw/coderabbit/BoardController.kt
+++ b/src/main/kotlin/io/devchw/coderabbit/BoardController.kt
@@ -23,7 +23,12 @@ class BoardController {
     private val posts = mutableMapOf<Long, Post>()
     private val idGenerator = AtomicLong(1)
 
-    // 게시물 생성
+    /**
+     * Creates a new post, assigns it a unique ID, and stores it in memory.
+     *
+     * @param post The post data to create.
+     * @return The created post with its assigned ID and HTTP status 201 (Created).
+     */
     @PostMapping
     fun createPost(@RequestBody post: Post): ResponseEntity<Post> {
         val id = idGenerator.getAndIncrement()
@@ -32,13 +37,24 @@ class BoardController {
         return ResponseEntity.status(HttpStatus.CREATED).body(post)
     }
 
-    // 게시물 목록 조회
+    /**
+     * Retrieves a list of all posts.
+     *
+     * @return HTTP 200 response containing all stored posts.
+     */
     @GetMapping
     fun getPosts(): ResponseEntity<List<Post>> {
         return ResponseEntity.ok(posts.values.toList())
     }
 
-    // 게시물 상세 조회
+    /**
+     * Retrieves a post by its unique ID.
+     *
+     * Returns the post with HTTP 200 if found, or HTTP 404 if no post exists with the given ID.
+     *
+     * @param id The unique identifier of the post to retrieve.
+     * @return A ResponseEntity containing the post if found, or a 404 status if not.
+     */
     @GetMapping("/{id}")
     fun getPost(@PathVariable id: Long): ResponseEntity<Post> {
         val post = posts[id]
@@ -49,7 +65,16 @@ class BoardController {
         }
     }
 
-    // 게시물 수정
+    /**
+     * Updates an existing post with new data by its ID.
+     *
+     * If the post with the specified ID does not exist, returns HTTP 404 (Not Found).
+     * Otherwise, replaces the post's content and returns the updated post with HTTP 200 (OK).
+     *
+     * @param id The ID of the post to update.
+     * @param updatedPost The new post data to replace the existing post.
+     * @return The updated post with HTTP 200, or HTTP 404 if the post does not exist.
+     */
     @PutMapping("/{id}")
     fun updatePost(@PathVariable id: Long, @RequestBody updatedPost: Post): ResponseEntity<Post> {
         if (!posts.containsKey(id)) {
@@ -60,7 +85,14 @@ class BoardController {
         return ResponseEntity.ok(updatedPost)
     }
 
-    // 게시물 삭제
+    /**
+     * Deletes a post by its ID.
+     *
+     * Removes the post with the specified ID from the in-memory store. Returns HTTP 204 (No Content) if the post was deleted, or HTTP 404 (Not Found) if the post does not exist.
+     *
+     * @param id The unique identifier of the post to delete.
+     * @return A ResponseEntity with HTTP status 204 if successful, or 404 if the post is not found.
+     */
     @DeleteMapping("/{id}")
     fun deletePost(@PathVariable id: Long): ResponseEntity<Void> {
         if (!posts.containsKey(id)) {

--- a/src/main/kotlin/io/devchw/coderabbit/BoardController.kt
+++ b/src/main/kotlin/io/devchw/coderabbit/BoardController.kt
@@ -1,0 +1,72 @@
+package io.devchw.coderabbit
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * @author DevCHW
+ * @since 2025-06-05
+ */
+@RestController
+@RequestMapping("/api/board")
+class BoardController {
+
+    private val posts = mutableMapOf<Long, Post>()
+    private val idGenerator = AtomicLong(1)
+
+    // 게시물 생성
+    @PostMapping
+    fun createPost(@RequestBody post: Post): ResponseEntity<Post> {
+        val id = idGenerator.getAndIncrement()
+        post.id = id
+        posts[id] = post
+        return ResponseEntity.status(HttpStatus.CREATED).body(post)
+    }
+
+    // 게시물 목록 조회
+    @GetMapping
+    fun getPosts(): ResponseEntity<List<Post>> {
+        return ResponseEntity.ok(posts.values.toList())
+    }
+
+    // 게시물 상세 조회
+    @GetMapping("/{id}")
+    fun getPost(@PathVariable id: Long): ResponseEntity<Post> {
+        val post = posts[id]
+        return if (post != null) {
+            ResponseEntity.ok(post)
+        } else {
+            ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+        }
+    }
+
+    // 게시물 수정
+    @PutMapping("/{id}")
+    fun updatePost(@PathVariable id: Long, @RequestBody updatedPost: Post): ResponseEntity<Post> {
+        if (!posts.containsKey(id)) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+        }
+        updatedPost.id = id
+        posts[id] = updatedPost
+        return ResponseEntity.ok(updatedPost)
+    }
+
+    // 게시물 삭제
+    @DeleteMapping("/{id}")
+    fun deletePost(@PathVariable id: Long): ResponseEntity<Void> {
+        if (!posts.containsKey(id)) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+        }
+        posts.remove(id)
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+    }
+}

--- a/src/main/kotlin/io/devchw/coderabbit/Comment.kt
+++ b/src/main/kotlin/io/devchw/coderabbit/Comment.kt
@@ -1,0 +1,11 @@
+package io.devchw.coderabbit
+
+/**
+ * @author DevCHW
+ * @since 2025-06-05
+ */
+data class Comment(
+    var id: Long? = null,
+    var postId: Long,
+    var content: String
+)

--- a/src/main/kotlin/io/devchw/coderabbit/CommentController.kt
+++ b/src/main/kotlin/io/devchw/coderabbit/CommentController.kt
@@ -1,0 +1,86 @@
+package io.devchw.coderabbit
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * @author DevCHW
+ * @since 2025-06-05
+ */
+@RestController
+@RequestMapping("/api/board")
+class CommentController {
+
+    private val comments = mutableMapOf<Long, Comment>()
+    private val idGenerator = AtomicLong(1)
+
+    // 댓글 생성
+    @PostMapping("/{postId}/comments")
+    fun createComment(
+        @PathVariable postId: Long, 
+        @RequestBody comment: Comment
+    ): ResponseEntity<Comment> {
+        val id = idGenerator.getAndIncrement()
+        comment.id = id
+        comment.postId = postId
+        comments[id] = comment
+        return ResponseEntity.status(HttpStatus.CREATED).body(comment)
+    }
+
+    // 게시물의 모든 댓글 조회
+    @GetMapping("/{postId}/comments")
+    fun getCommentsByPost(@PathVariable postId: Long): ResponseEntity<List<Comment>> {
+        val postComments = comments.values.filter { it.postId == postId }
+        return ResponseEntity.ok(postComments)
+    }
+
+    // 댓글 상세 조회
+    @GetMapping("/comments/{commentId}")
+    fun getComment(@PathVariable commentId: Long): ResponseEntity<Comment> {
+        val comment = comments[commentId]
+        return if (comment != null) {
+            ResponseEntity.ok(comment)
+        } else {
+            ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+        }
+    }
+
+    // 댓글 수정
+    @PutMapping("/comments/{commentId}")
+    fun updateComment(
+        @PathVariable commentId: Long, 
+        @RequestBody updatedComment: Comment
+    ): ResponseEntity<Comment> {
+        val existingComment = comments[commentId]
+        if (existingComment == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+        }
+
+        // 기존 postId 유지
+        updatedComment.id = commentId
+        updatedComment.postId = existingComment.postId
+        comments[commentId] = updatedComment
+        return ResponseEntity.ok(updatedComment)
+    }
+
+    // 댓글 삭제
+    @DeleteMapping("/comments/{commentId}")
+    fun deleteComment(@PathVariable commentId: Long): ResponseEntity<Void> {
+        if (!comments.containsKey(commentId)) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+        }
+        comments.remove(commentId)
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+    }
+
+    // 게시물의 모든 댓글 삭제 (게시물이 삭제될 때 호출)
+    fun deleteAllCommentsForPost(postId: Long) {
+        val commentIdsToRemove = comments.values
+            .filter { it.postId == postId }
+            .mapNotNull { it.id }
+
+        commentIdsToRemove.forEach { comments.remove(it) }
+    }
+}

--- a/src/main/kotlin/io/devchw/coderabbit/Post.kt
+++ b/src/main/kotlin/io/devchw/coderabbit/Post.kt
@@ -1,0 +1,11 @@
+package io.devchw.coderabbit
+
+/**
+ * @author DevCHW
+ * @since 2025-06-05
+ */
+data class Post(
+    var id: Long? = null,
+    var title: String,
+    var content: String
+)

--- a/src/main/kotlin/io/devchw/coderabbit/Post.kt
+++ b/src/main/kotlin/io/devchw/coderabbit/Post.kt
@@ -7,5 +7,6 @@ package io.devchw.coderabbit
 data class Post(
     var id: Long? = null,
     var title: String,
-    var content: String
+    var content: String,
+    var comments: MutableList<Comment> = mutableListOf()
 )


### PR DESCRIPTION
### 작업 내용
- 게시판 CRUD API 구현.
- `Map`을 사용해 간단한 데이터 저장소로 활용.

### 주요 기능
1. **게시물 생성** (`POST /api/board`)
2. **게시물 목록 조회** (`GET /api/board`)
3. **게시물 상세 조회** (`GET /api/board/{id}`)
4. **게시물 수정** (`PUT /api/board/{id}`)
5. **게시물 삭제** (`DELETE /api/board/{id}`)

### 구현 방식
- 데이터 클래스 작성 (필드: , , ). `Post``id``title``content`
- 으로 ID 자동 생성 및 관리. `AtomicLong`
- HTTP 상태 코드 201, 200, 404, 204 적절히 반환.

### 비고
- 현재 데이터는 `Map`에 저장되며 서버 종료 시 초기화됩니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a board post system with RESTful API endpoints for creating, viewing, updating, and deleting posts.
  - Users can now manage posts with unique IDs, including listing all posts or retrieving a specific post by ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->